### PR TITLE
Add Vitest suite and npm test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Run the following from the project root:
 | `npm run dev`    | Start the development server         |
 | `npm run build`  | Build the production version in `dist/` |
 | `npm run preview`| Preview the built site locally       |
+| `npm test`       | Run the test suite                  |
 
 ## Learn More
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "test": "vitest"
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.4",

--- a/src/React/LetterGlitch.test.tsx
+++ b/src/React/LetterGlitch.test.tsx
@@ -1,0 +1,18 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import LetterGlitch from './LetterGlitch';
+
+describe('LetterGlitch', () => {
+  beforeAll(() => {
+    vi.stubGlobal('cancelAnimationFrame', () => {});
+    vi.stubGlobal('requestAnimationFrame', () => 1);
+    HTMLCanvasElement.prototype.getContext = vi.fn();
+  });
+  it('renders a canvas element', () => {
+    const { container } = render(
+      <LetterGlitch glitchColors={['#000000']} glitchSpeed={50} centerVignette={false} outerVignette={false} smooth={true} />,
+    );
+    const canvas = container.querySelector('canvas');
+    expect(canvas).not.toBeNull();
+  });
+});

--- a/src/React/SkillsList.test.tsx
+++ b/src/React/SkillsList.test.tsx
@@ -1,17 +1,17 @@
+import { describe, it, expect } from "vitest";
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { fireEvent } from '@testing-library/react';
 import SkillsList from './SkillsList';
 
 describe('SkillsList', () => {
-  it('opens and closes a category', async () => {
-    const user = userEvent.setup();
+  it('opens and closes a category', () => {
     render(<SkillsList />);
     const header = screen.getByText('Web Development');
     const details = header.parentElement!.parentElement!.parentElement!.nextElementSibling as HTMLElement;
     expect(details.className).toContain('max-h-0');
-    await user.click(header);
+    fireEvent.click(header);
     expect(details.className).toContain('max-h-[500px]');
-    await user.click(header);
+    fireEvent.click(header);
     expect(details.className).toContain('max-h-0');
   });
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,1 @@
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';


### PR DESCRIPTION
## Summary
- document `npm test` in README
- add `test:watch` script and run mode for Vitest
- fix `SkillsList.test` imports
- add new test for `LetterGlitch`
- use Vitest version of jest-dom

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fed0e6ad8832a8e2948f97b1515f8