### PR TITLE
Change email for contact form

### DIFF
--- a/src/components/contact.astro
+++ b/src/components/contact.astro
@@ -63,7 +63,7 @@
     
     const subject = encodeURIComponent("Message from " + fromName);
     const body = encodeURIComponent("Name: " + fromName + "\nEmail: " + replyTo + "\nMessage:\n" + message);
-    const mailtoLink = `mailto:your@email.com?subject=${subject}&body=${body}`;
+    const mailtoLink = `mailto:m0rg0t.anton@gmail.com?subject=${subject}&body=${body}`;
     
     window.location.href = mailtoLink;
     form.style.display = 'none';


### PR DESCRIPTION
## Summary
- update the `mailto:` link in the contact form to use `m0rg0t.anton@gmail.com`

## Testing
- `npm test -- --run` *(fails: ReferenceError: expect is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_683ffaaf43c4832a8cc3fe32281dbffc